### PR TITLE
Make HTML_RESULTS_DIR configurable

### DIFF
--- a/microbenchmarks/locust_runner.py
+++ b/microbenchmarks/locust_runner.py
@@ -15,7 +15,7 @@ import argparse
 import subprocess
 from tqdm import tqdm
 
-HTML_RESULTS_DIR = "locust_results"
+HTML_RESULTS_DIR = os.environ.get("HTML_RESULTS_DIR", "locust_results")
 DEFAULT_RESULT_FILENAME = f"{time.strftime('%Y-%m-%d-%p-%H-%M-%S-results.html')}"
 
 parser = argparse.ArgumentParser()


### PR DESCRIPTION
```python
# test.py
import os
HTML_RESULTS_DIR = os.environ.get("HTML_RESULTS_DIR", "locust_results")
print(HTML_RESULTS_DIR)
```

* `python3 test.py` => `locust_results`
* `HTML_RESULTS_DIR=123 python3 test.py` => `123`