### PR TITLE
Make Locust wait_time configurable

### DIFF
--- a/microbenchmarks/qps_test_locustfile.py
+++ b/microbenchmarks/qps_test_locustfile.py
@@ -1,6 +1,7 @@
 from random import choice
 from string import printable
 from locust import FastHttpUser, task, constant, events
+import os
 
 
 def generate_random_string(size: int):
@@ -30,7 +31,7 @@ def _(environment, **kw):
 
 
 class ConstantUser(FastHttpUser):
-    wait_time = constant(0)
+    wait_time = constant(float(os.environ.get("LOCUS_WAIT_TIME", "0")))
     network_timeout = None
     connection_timeout = None
 


### PR DESCRIPTION
When `wait_time` is set to `constant(0)`, the latency tends to be very high. However, using a non-zero `wait_time` along with a greater number of users can achieve the same QPS, but with significantly reduced latency.