### PR TITLE
fix serialization issue

### DIFF
--- a/chaos_test/receiver.py
+++ b/chaos_test/receiver.py
@@ -75,8 +75,13 @@ class NodeKiller:
         try:
             actors = list_actors(filters=[("state", "=", "ALIVE")], timeout=3)
             # Convert ActorState objects to dictionaries for JSON serialization
-            actors_dict = [vars(actor) for actor in actors]
-            logger.info(f"Actor summary:\n{json.dumps(actors_dict, indent=4, default=str)}")
+            try:
+                actors_dict = [vars(actor) for actor in actors]
+                actors_json = json.dumps(actors_dict, indent=4, default=str)
+            except (TypeError, ValueError):
+                # If JSON serialization still fails, just use string representation
+                actors_json = str(actors)
+            logger.info(f"Actor summary:\n{actors_json}")
         except Exception as e:
             logger.error(f"Failed to get actor info: {e}")
         logger.info(f"Killing node {ray.get_runtime_context().get_node_id()}")
@@ -87,8 +92,13 @@ class NodeKiller:
         try:
             actors = list_actors(filters=[("state", "=", "ALIVE")], timeout=3)
             # Convert ActorState objects to dictionaries for JSON serialization
-            actors_dict = [vars(actor) for actor in actors]
-            logger.info(f"Actor summary:\n{json.dumps(actors_dict, indent=4, default=str)}")
+            try:
+                actors_dict = [vars(actor) for actor in actors]
+                actors_json = json.dumps(actors_dict, indent=4, default=str)
+            except (TypeError, ValueError):
+                # If JSON serialization still fails, just use string representation
+                actors_json = str(actors)
+            logger.info(f"Actor summary:\n{actors_json}")
         except Exception as e:
             logger.error(f"Failed to get actor info: {e}")
         logger.info(f"Killing node {ray.get_runtime_context().get_node_id()}")

--- a/chaos_test/receiver.py
+++ b/chaos_test/receiver.py
@@ -74,9 +74,11 @@ class NodeKiller:
     def ray_stop_node(self):
         try:
             actors = list_actors(filters=[("state", "=", "ALIVE")], timeout=3)
-            logger.info(f"Actor summary:\n{json.dumps(actors, indent=4)}")
-        except Exception:
-            logger.exception(f"Failed to get actor info.")
+            # Convert ActorState objects to dictionaries for JSON serialization
+            actors_dict = [vars(actor) for actor in actors]
+            logger.info(f"Actor summary:\n{json.dumps(actors_dict, indent=4, default=str)}")
+        except Exception as e:
+            logger.error(f"Failed to get actor info: {e}")
         logger.info(f"Killing node {ray.get_runtime_context().get_node_id()}")
         subprocess.call(["ray", "stop", "-f"])
         return ""
@@ -84,9 +86,11 @@ class NodeKiller:
     def halt_node(self):
         try:
             actors = list_actors(filters=[("state", "=", "ALIVE")], timeout=3)
-            logger.info(f"Actor summary:\n{json.dumps(actors, indent=4)}")
-        except Exception:
-            logger.exception(f"Failed to get actor info.")
+            # Convert ActorState objects to dictionaries for JSON serialization
+            actors_dict = [vars(actor) for actor in actors]
+            logger.info(f"Actor summary:\n{json.dumps(actors_dict, indent=4, default=str)}")
+        except Exception as e:
+            logger.error(f"Failed to get actor info: {e}")
         logger.info(f"Killing node {ray.get_runtime_context().get_node_id()}")
         subprocess.call(["sudo", "halt", "--force"])
         return ""


### PR DESCRIPTION
receiver.py in chaos-testing is throwing error
```
traceback.py:121 -   File "/tmp/ray/session_2025-11-11_21-14-51_580313_2243/runtime_resources/working_dir_files/https_github_com_ray-project_serve_workloads_archive_c3e6b99060fdc16870af59f2ebfa7601d3ccb49d/chaos_test/receiver.py", line 87, in halt_node
    logger.info(f"Actor summary:\n{json.dumps(actors, indent=4)}")
I
2025-11-12 11:24:39.965	replica	dbe846b7-f5f4-4137-94fb-9d8fa0b8af59	ip-10-0-121-22	traceback.py:121 -   File "/home/ray/anaconda3/lib/python3.10/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
I
2025-11-12 11:24:39.965	replica	dbe846b7-f5f4-4137-94fb-9d8fa0b8af59	ip-10-0-121-22	traceback.py:121 -   File "/home/ray/anaconda3/lib/python3.10/json/encoder.py", line 201, in encode
    chunks = list(chunks)
I
2025-11-12 11:24:39.965	replica	dbe846b7-f5f4-4137-94fb-9d8fa0b8af59	ip-10-0-121-22	traceback.py:121 -   File "/home/ray/anaconda3/lib/python3.10/json/encoder.py", line 429, in _iterencode
    yield from _iterencode_list(o, _current_indent_level)
I
2025-11-12 11:24:39.965	replica	dbe846b7-f5f4-4137-94fb-9d8fa0b8af59	ip-10-0-121-22	traceback.py:121 -   File "/home/ray/anaconda3/lib/python3.10/json/encoder.py", line 325, in _iterencode_list
    yield from chunks
I
2025-11-12 11:24:39.965	replica	dbe846b7-f5f4-4137-94fb-9d8fa0b8af59	ip-10-0-121-22	traceback.py:121 -   File "/home/ray/anaconda3/lib/python3.10/json/encoder.py", line 438, in _iterencode
    o = _default(o)
I
2025-11-12 11:24:39.965	replica	dbe846b7-f5f4-4137-94fb-9d8fa0b8af59	ip-10-0-121-22	traceback.py:121 -   File "/home/ray/anaconda3/lib/python3.10/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
I
2025-11-12 11:24:39.965	replica	dbe846b7-f5f4-4137-94fb-9d8fa0b8af59	ip-10-0-121-22	traceback.py:121 - TypeError: Object of type ActorState is not JSON serializable
I
2025-11-12 11:24:39.965	replica	dbe846b7-f5f4-4137-94fb-9d8fa0b8af59	ip-10-0-121-22	traceback.py:121 - 
During handling of the above exception, another exception occurred:

I
2025-11-12 11:24:39.965	replica	dbe846b7-f5f4-4137-94fb-9d8fa0b8af59	ip-10-0-121-22	traceback.py:121 - Traceback (most recent call last):
I
2025-11-12 11:24:39.965	replica	dbe846b7-f5f4-4137-94fb-9d8fa0b8af59	ip-10-0-121-22	traceback.py:121 -   File "/home/ray/anaconda3/lib/python3.10/logging/__init__.py", line 1100, in emit
    msg = self.format(record)
I
2025-11-12 11:24:39.965	replica	dbe846b7-f5f4-4137-94fb-9d8fa0b8af59	ip-10-0-121-22	traceback.py:121 -   File "/home/ray/anaconda3/lib/python3.10/logging/__init__.py", line 943, in format
    return fmt.format(record)
I
2025-11-12 11:24:39.965	replica	dbe846b7-f5f4-4137-94fb-9d8fa0b8af59	ip-10-0-121-22	traceback.py:121 -   File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/serve/_private/logging_utils.py", line 103, in format
    record_attributes = copy.deepcopy(record.__dict__)
I
2025-11-12 11:24:39.965	replica	dbe846b7-f5f4-4137-94fb-9d8fa0b8af59	ip-10-0-121-22	traceback.py:121 -   File "/home/ray/anaconda3/lib/python3.10/copy.py", line 146, in deepcopy
    y = copier(x, memo)
I
2025-11-12 11:24:39.965	replica	dbe846b7-f5f4-4137-94fb-9d8fa0b8af59	ip-10-0-121-22	traceback.py:121 -   File "/home/ray/anaconda3/lib/python3.10/copy.py", line 231, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
I
2025-11-12 11:24:39.965	replica	dbe846b7-f5f4-4137-94fb-9d8fa0b8af59	ip-10-0-121-22	traceback.py:121 -   File "/home/ray/anaconda3/lib/python3.10/copy.py", line 146, in deepcopy
    y = copier(x, memo)
I
2025-11-12 11:24:39.965	replica	dbe846b7-f5f4-4137-94fb-9d8fa0b8af59	ip-10-0-121-22	traceback.py:121 -   File "/home/ray/anaconda3/lib/python3.10/copy.py", line 211, in _deepcopy_tuple
    y = [deepcopy(a, memo) for a in x]
I
2025-11-12 11:24:39.965	replica	dbe846b7-f5f4-4137-94fb-9d8fa0b8af59	ip-10-0-121-22	traceback.py:121 -   File "/home/ray/anaconda3/lib/python3.10/copy.py", line 211, in <listcomp>
    y = [deepcopy(a, memo) for a in x]
I
2025-11-12 11:24:39.965	replica	dbe846b7-f5f4-4137-94fb-9d8fa0b8af59	ip-10-0-121-22	traceback.py:121 -   File "/home/ray/anaconda3/lib/python3.10/copy.py", line 161, in deepcopy
    rv = reductor(4)
I
2025-11-12 11:24:39.965	replica	dbe846b7-f5f4-4137-94fb-9d8fa0b8af59	ip-10-0-121-22	traceback.py:121 - TypeError: cannot pickle 'traceback' object
I
2025-11-12 11:24:39.965	replica	dbe846b7-f5f4-4137-94fb-9d8fa0b8af59	ip-10-0-121-22	handlers.py:75 - Call stack:
I
2025-11-12 11:24:39.965	replica	dbe846b7-f5f4-4137-94fb-9d8fa0b8af59	ip-10-0-121-22	traceback.py:25 -   File "/home/ray/anaconda3/lib/python3.10/threading.py", line 973, in _bootstrap
    self._bootstrap_inner()
I
2025-11-12 11:24:39.965	replica	dbe846b7-f5f4-4137-94fb-9d8fa0b8af59	ip-10-0-121-22	traceback.py:25 -   File "/home/ray/anaconda3/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
I
2025-11-12 11:24:39.965	replica	dbe846b7-f5f4-4137-94fb-9d8fa0b8af59	ip-10-0-121-22	traceback.py:25 -   File "/home/ray/anaconda3/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
I
2025-11-12 11:24:39.965	replica	dbe846b7-f5f4-4137-94fb-9d8fa0b8af59	ip-10-0-121-22	traceback.py:25 -   File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/serve/_private/replica.py", line 751, in _run_user_code_event_loop
    self._user_code_event_loop.run_forever()
I
2025-11-12 11:24:39.965	replica	dbe846b7-f5f4-4137-94fb-9d8fa0b8af59	ip-10-0-121-22	traceback.py:25 -   File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/serve/_private/replica.py", line 1102, in call_user_method
    await self._call_func_or_gen(
I
2025-11-12 11:24:39.965	replica	dbe846b7-f5f4-4137-94fb-9d8fa0b8af59	ip-10-0-121-22	traceback.py:25 -   File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/serve/_private/replica.py", line 826, in _call_func_or_gen
    result = callable(*args, **kwargs)
I
2025-11-12 11:24:39.965	replica	dbe846b7-f5f4-4137-94fb-9d8fa0b8af59	ip-10-0-121-22	traceback.py:25 -   File "/tmp/ray/session_2025-11-11_21-14-51_580313_2243/runtime_resources/working_dir_files/https_github_com_ray-project_serve_workloads_archive_c3e6b99060fdc16870af59f2ebfa7601d3ccb49d/chaos_test/receiver.py", line 89, in halt_node
    logger.exception(f"Failed to get actor info.")
```

which might be the reason for increasing Error QPS. it's a try to fix that issue by serializing the content we are printing in the logger