### PR TITLE
Post locust results to Slack as a thread: criteria, percentiles, P50 ratios

### DIFF
--- a/staging_test_service/README.md
+++ b/staging_test_service/README.md
@@ -94,7 +94,9 @@ Tune scale via environment variables:
 | `LOCUST_RUN_MINUTES` | `150` | Total run duration (24-hour cycle compressed into this) |
 | `LOCUST_PEAK_USERS` | `2000` | Locust user count at 1.0x load multiplier |
 | `ANYSCALE_SERVICE_TOKEN` | — | Bearer token for Anyscale Service auth |
-| `SLACK_WEBHOOK_URL` | — | Optional Slack incoming webhook for final Locust result notification |
+| `SLACK_BOT_TOKEN` | — | Slack bot token (`xoxb-…`); enables the threaded result post (summary + acceptance-criteria, percentiles, and P50-ratio replies) |
+| `SLACK_CHANNEL` | — | Slack channel ID (or public channel name) for the threaded result post |
+| `SLACK_WEBHOOK_URL` | — | Fallback Slack incoming webhook; used only when the bot token/channel are unset (single message, no thread) |
 | `LOCUST_RESULTS_ROOT` | `/tmp/locust-results` | Root directory for Locust CSV/HTML artifacts |
 | `LOCUST_PROCESSES` | `16` | Default process count used by `run_locust_test.py` |
 
@@ -154,7 +156,8 @@ anyscale schedule run --name serve-validation-locust-daily
 |---|---|---|
 | `ANYSCALE_SERVICE_CONFIG` | `upgrade_service.py` | Path to service YAML (default: `anyscale_service.yaml`) |
 | `UPGRADE_WAIT_TIMEOUT_S` | `upgrade_service.py` | Timeout for `anyscale service wait` (default: `1200`) |
-| `SLACK_WEBHOOK_URL` | `upgrade_service.py`, `run_locust_test.py` | Slack incoming webhook for deploy and Locust result notifications |
+| `SLACK_BOT_TOKEN`, `SLACK_CHANNEL` | `run_locust_test.py` | Slack Web API credentials for the threaded Locust result post |
+| `SLACK_WEBHOOK_URL` | `upgrade_service.py`, `run_locust_test.py` | Slack incoming webhook for deploy notifications; Locust fallback when bot token unset |
 | `ANYSCALE_SERVICE_TOKEN` | `locustfile.py` | Bearer token injected into all Locust requests |
 | `LOCUST_PEAK_USERS` | `locustfile.py` | User count at 1.0x load (default: `2000`) |
 | `LOCUST_RUN_MINUTES` | `locustfile.py` | Run duration in minutes (default: `150`) |

--- a/staging_test_service/run_locust_test.py
+++ b/staging_test_service/run_locust_test.py
@@ -31,8 +31,11 @@ class LocustStats:
     failure_count: int
     avg_response_ms: Optional[float]
     requests_per_s: Optional[float]
+    p50_ms: Optional[float]
+    p90_ms: Optional[float]
     p95_ms: Optional[float]
     p99_ms: Optional[float]
+    p999_ms: Optional[float]
 
     @property
     def failure_rate(self) -> float:
@@ -71,8 +74,11 @@ def parse_stats_csv(stats_path: Path) -> Optional[LocustStats]:
                 failure_count=_int_value(row.get("Failure Count")),
                 avg_response_ms=_float_value(row.get("Average Response Time")),
                 requests_per_s=_float_value(row.get("Requests/s")),
+                p50_ms=_float_value(row.get("50%")),
+                p90_ms=_float_value(row.get("90%")),
                 p95_ms=_float_value(row.get("95%")),
                 p99_ms=_float_value(row.get("99%")),
+                p999_ms=_float_value(row.get("99.9%")),
             )
 
     return None
@@ -147,9 +153,24 @@ def build_slack_message(
     if error:
         lines.extend(["", f"*Error:* {error}"])
 
-    lines.extend(
+    return "\n".join(lines)
+
+
+# Latency-shape bands (ratio to P50) from the acceptance criteria doc:
+# (label, stats attribute, healthy range, warning threshold).
+RATIO_BANDS = (
+    ("P50", "p50_ms", "baseline", None),
+    ("P90", "p90_ms", "1.2x - 1.5x", 3.0),
+    ("P95", "p95_ms", "1.5x - 2.5x", 4.0),
+    ("P99", "p99_ms", "3x - 5x", 10.0),
+    ("P99.9", "p999_ms", "10x - 20x", 50.0),
+)
+
+
+def build_criteria_reply() -> str:
+    """Thread reply 1: acceptance criteria link."""
+    return "\n".join(
         [
-            "",
             f"Acceptance criteria: <{ACCEPTANCE_CRITERIA_URL}|Staging Test Service>",
             (
                 "_Note: If the failure rate is >= 0.01%, this may signify "
@@ -158,6 +179,48 @@ def build_slack_message(
         ]
     )
 
+
+def build_percentiles_reply(stats: Optional[LocustStats]) -> str:
+    """Thread reply 2: response-time percentiles of the aggregated run."""
+    if stats is None:
+        return "*Response time percentiles*\nNo Locust stats CSV was produced."
+    lines = ["*Response time percentiles* (aggregated)"]
+    for label, attr, _, _ in RATIO_BANDS:
+        lines.append(f"- {label}: {_format_optional_ms(getattr(stats, attr))}")
+    return "\n".join(lines)
+
+
+def build_ratio_reply(stats: Optional[LocustStats]) -> str:
+    """Thread reply 3: latency shape as ratio-to-P50, warnings marked."""
+    header = "*Latency shape* (ratio to P50)"
+    if stats is None:
+        return f"{header}\nNo Locust stats CSV was produced."
+    if not stats.p50_ms or stats.p50_ms <= 0:
+        return f"{header}\nP50 unavailable; cannot compute ratios."
+
+    rows = [f"{'Percentile':<11}{'Actual':>12}{'Ratio':>9}  {'Healthy':<13}{'Warning':<9}"]
+    breached = []
+    for label, attr, healthy, warn_threshold in RATIO_BANDS:
+        value = getattr(stats, attr)
+        if value is None:
+            rows.append(f"{label:<11}{'N/A':>12}{'N/A':>9}  {healthy:<13}{'-':<9}")
+            continue
+        ratio = value / stats.p50_ms
+        warn_col = f">{warn_threshold:g}x" if warn_threshold else "-"
+        mark = ""
+        if warn_threshold and ratio > warn_threshold:
+            mark = "  << WARNING"
+            breached.append(f"{label} is {ratio:.1f}x P50 (warning threshold >{warn_threshold:g}x)")
+        rows.append(
+            f"{label:<11}{_format_optional_ms(value):>12}{f'{ratio:.1f}x':>9}"
+            f"  {healthy:<13}{warn_col:<9}{mark}"
+        )
+
+    lines = [header, "```", *rows, "```"]
+    if breached:
+        lines.extend(f":warning: {msg}" for msg in breached)
+    else:
+        lines.append("All percentile ratios are below their warning thresholds.")
     return "\n".join(lines)
 
 
@@ -172,6 +235,58 @@ def post_slack(webhook: str, text: str, ok: bool) -> None:
         urllib.request.urlopen(req, timeout=10)
     except Exception as exc:
         print(f"Slack notification failed: {exc}", file=sys.stderr)
+
+
+def _slack_api_post(token: str, payload: dict) -> dict:
+    req = urllib.request.Request(
+        "https://slack.com/api/chat.postMessage",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Content-Type": "application/json; charset=utf-8",
+            "Authorization": f"Bearer {token}",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def post_slack_thread(
+    token: str, channel: str, text: str, replies: Sequence[str], ok: bool
+) -> bool:
+    """Post the summary, then each reply in its thread. Returns True if the
+    summary was posted (replies are best-effort). Never raises: a Slack
+    failure must not mask Locust's exit code."""
+    try:
+        main = _slack_api_post(
+            token,
+            {
+                "channel": channel,
+                "text": text,
+                "attachments": [{"color": "good" if ok else "danger"}],
+                "unfurl_links": False,
+            },
+        )
+        if not main.get("ok"):
+            print(f"Slack chat.postMessage failed: {main.get('error')}", file=sys.stderr)
+            return False
+        thread_ts = main["ts"]
+        channel_id = main.get("channel", channel)
+        for reply in replies:
+            res = _slack_api_post(
+                token,
+                {
+                    "channel": channel_id,
+                    "thread_ts": thread_ts,
+                    "text": reply,
+                    "unfurl_links": False,
+                },
+            )
+            if not res.get("ok"):
+                print(f"Slack thread reply failed: {res.get('error')}", file=sys.stderr)
+        return True
+    except Exception as exc:
+        print(f"Slack notification failed: {exc}", file=sys.stderr)
+        return False
 
 
 def _timestamp() -> str:
@@ -332,10 +447,29 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         error=error,
     )
 
-    print(text)
+    replies = [
+        build_criteria_reply(),
+        build_percentiles_reply(stats),
+        build_ratio_reply(stats),
+    ]
+    print("\n\n".join([text, *replies]))
+
+    # Threaded posting (summary + 3 replies) needs the Web API; incoming
+    # webhooks return no message ts, so they cannot start a thread.
+    token = os.environ.get("SLACK_BOT_TOKEN")
+    channel = os.environ.get("SLACK_CHANNEL")
     webhook = os.environ.get("SLACK_WEBHOOK_URL")
-    if webhook:
-        post_slack(webhook, text, ok=ok)
+    posted = False
+    if token and channel:
+        posted = post_slack_thread(token, channel, text, replies, ok=ok)
+    elif webhook:
+        print(
+            "SLACK_BOT_TOKEN/SLACK_CHANNEL unset; falling back to webhook "
+            "(single message, no thread).",
+            file=sys.stderr,
+        )
+    if not posted and webhook:
+        post_slack(webhook, "\n\n".join([text, *replies]), ok=ok)
 
     return exit_code
 

--- a/staging_test_service/schedules/locust_loadtest.yaml
+++ b/staging_test_service/schedules/locust_loadtest.yaml
@@ -14,6 +14,8 @@ job_config:
   env_vars:
     ANYSCALE_SERVICE_TOKEN: "${ANYSCALE_SERVICE_TOKEN}"
     SLACK_WEBHOOK_URL: "${SLACK_WEBHOOK_URL}"
+    SLACK_BOT_TOKEN: "${SLACK_BOT_TOKEN}"
+    SLACK_CHANNEL: "${SLACK_CHANNEL}"
     LOCUST_RUN_MINUTES: "60"
   working_dir: .
   requirements: requirements.txt

--- a/staging_test_service/schedules/locust_loadtest_daily.yaml
+++ b/staging_test_service/schedules/locust_loadtest_daily.yaml
@@ -14,6 +14,8 @@ job_config:
   env_vars:
     ANYSCALE_SERVICE_TOKEN: "${ANYSCALE_SERVICE_TOKEN}"
     SLACK_WEBHOOK_URL: "${SLACK_WEBHOOK_URL}"
+    SLACK_BOT_TOKEN: "${SLACK_BOT_TOKEN}"
+    SLACK_CHANNEL: "${SLACK_CHANNEL}"
     LOCUST_RUN_MINUTES: "15"
   working_dir: .
   requirements: requirements.txt


### PR DESCRIPTION
## What

The locust result notification was a single webhook message with the acceptance-criteria link inline. This restructures it into a **summary message + three threaded replies**:

1. **Acceptance criteria link** (moved out of the summary body)
2. **Response-time percentiles** of the aggregated run: P50 / P90 / P95 / P99 / P99.9
3. **Latency shape as ratios to P50**, rendered against the healthy bands from the acceptance criteria, with any percentile breaching its warning threshold marked in the table and called out below it:

| Percentile | Healthy (ratio to P50) | Warning |
| --- | --- | --- |
| P50 | 1.0x | baseline |
| P90 | 1.2x – 1.5x | > 3x |
| P95 | 1.5x – 2.5x | > 4x |
| P99 | 3x – 5x | > 10x |
| P99.9 | 10x – 20x | > 50x |

Example of reply 3 with breaches:

```
Percentile       Actual    Ratio  Healthy      Warning
P50            45.00 ms     1.0x  baseline     -
P90           100.00 ms     2.2x  1.2x - 1.5x  >3x
P95           200.00 ms     4.4x  1.5x - 2.5x  >4x        << WARNING
P99           400.00 ms     8.9x  3x - 5x      >10x
P99.9        2400.00 ms    53.3x  10x - 20x    >50x       << WARNING
```
> :warning: P95 is 4.4x P50 (warning threshold >4x)
> :warning: P99.9 is 53.3x P50 (warning threshold >50x)

## How

Incoming webhooks cannot start threads — Slack returns no message `ts` for them. Threaded posting therefore uses the Web API (`chat.postMessage`) via two new env vars, plumbed through both locust schedule YAMLs:

- `SLACK_BOT_TOKEN` — bot token (`xoxb-…`) with `chat:write` scope
- `SLACK_CHANNEL` — channel ID (or public channel name the bot is in)

**Fallback:** when they're unset, the script logs a note and posts everything as one webhook message, so currently-applied schedules keep working unchanged. Re-apply the schedules with the new vars exported to enable threading:

```bash
export SLACK_BOT_TOKEN=... SLACK_CHANNEL=...
envsubst < schedules/locust_loadtest.yaml | anyscale schedule apply -f -
envsubst < schedules/locust_loadtest_daily.yaml | anyscale schedule apply -f -
```

## Verification

Local (not committed): drove `parse_stats_csv` + the three builders with synthetic locust stats CSVs — healthy run, breaching run (markers and callouts correct), missing CSV, and zero-P50 (graceful, no div-by-zero) — and the posting flow against a mocked `chat.postMessage`: 1 summary + 3 replies all carrying `thread_ts`, replies reuse the returned channel ID, and a failed summary post returns False so the webhook fallback engages. Slack failures never mask Locust's exit code (the regression signal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)