### PR TITLE
Pin baseline pinger aiohttp to 3.14.1 (heavy-truncation confirmation experiment)

### DIFF
--- a/staging_test_service/requirements.txt
+++ b/staging_test_service/requirements.txt
@@ -5,5 +5,6 @@ pydantic>=2.0
 urllib3>=2.0.5,<2.1
 
 # baseline_pinger.py — async HTTP client + retry (mirrors chaos_test/Dockerfile)
-aiohttp
+# aiohttp pinned to latest for the heavy-truncation confirmation experiment (pod was on 3.13.3).
+aiohttp==3.14.1
 aiohttp-retry


### PR DESCRIPTION
## What

Pins the baseline pinger's `aiohttp` to **3.14.1** (latest; the pod was running 3.13.3, unpinned). Pinger-only, one line in `staging_test_service/requirements.txt`.

## Why (and the honest expectation)

The always-on pinger hits a rare `ClientPayloadError` / `ContentLengthError` on the 1 MiB `/heavy-payload/` response (~1 in 32k-96k, heavy-only). A deep RCA on the **exact production stack** (Python 3.10 + aiohttp 3.13.3 + the compiled C parser) concluded the bytes are **genuinely short on the wire** (a truncation on the ALB-to-pinger leg ending in a TCP FIN, not a reset), **not** a client/parser false-positive:

- A fully-delivered 1 MiB body never raises this across 11,000+ trials (32-way concurrency, 192-239 MB/s, buffer-boundary-aligned, slow-consumer jitter).
- The C parser raises iff strictly fewer than Content-Length bytes are fed; cutting even 1 byte off the wire reproduces the exact error.
- A genuine bare-FIN truncation reproduces the identical no-suffix error on Python 3.12 too, and the 3.10->3.14 changelog has no relevant fix.

So **this bump is a confirmation experiment, not a fix.** Expected outcome: the failure rate holds, which rules the client out for good and points firmly at the edge/path. If instead it drops to zero over enough volume, the RCA was wrong and there was a version-specific client behavior worth knowing.

Bonus: aiohttp 3.14 adds expected/received byte counts to the `ContentLengthError` message, so the next failure will self-report exactly how many bytes were short (confirms + quantifies a real wire truncation). Not added instrumentation, just the newer library's better error text.

## How to run it so the result is interpretable

The rate is ~1/32k-96k, so do **not** judge by a quiet day (~3-5 expected failures/day at 2 heavy req/s). Either:
- run this upgraded pinger **in parallel** with the current one against the same ingress and compare `ClientPayloadError` counts, or
- temporarily raise heavy volume on the canary to accumulate **>100-200k** heavy requests and compare the *rate* to the ~1/32k baseline.

## Notes

- Needs a **baseline-pinger redeploy** to take effect (`envsubst < baseline_pinger_service.yaml | anyscale service deploy -f -`).
- If the build's package index lacks 3.14.1 (some mirrors are behind; this sandbox's capped at 3.13.5), fall back to `aiohttp==3.13.5` (note: the 3.14 better-error-message only lands on 3.14.x).
- **Bigger lever, not included here:** the sslproto rewrite is in Python 3.11+. Testing it needs a `py311`/`py312` Ray base image (the current image is `py310`), which the py3.12 repro already predicts won't change a genuine truncation. Switch the image only if you want to be exhaustive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)